### PR TITLE
Adicionar seletor de logos

### DIFF
--- a/src/assets/logo-placeholder1.svg
+++ b/src/assets/logo-placeholder1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <rect width="200" height="200" fill="#cccccc" />
+  <text x="100" y="100" font-size="24" text-anchor="middle" dominant-baseline="middle" fill="#333333">P1</text>
+</svg>

--- a/src/assets/logo-placeholder2.svg
+++ b/src/assets/logo-placeholder2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <rect width="200" height="200" fill="#cccccc" />
+  <text x="100" y="100" font-size="24" text-anchor="middle" dominant-baseline="middle" fill="#333333">P2</text>
+</svg>

--- a/src/assets/logo-placeholder3.svg
+++ b/src/assets/logo-placeholder3.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <rect width="200" height="200" fill="#cccccc" />
+  <text x="100" y="100" font-size="24" text-anchor="middle" dominant-baseline="middle" fill="#333333">P3</text>
+</svg>

--- a/src/index.pug
+++ b/src/index.pug
@@ -12,8 +12,11 @@ html(lang="en")
       .holo-bg(data-depth="0.1")
       .holo-lines(data-depth="0.3")
       .logo(data-depth="0.6")
-    
+
+    button#logo-menu-toggle.logo-menu-toggle 🖼️
+    #logo-menu.logo-menu
+
     script(src="https://cdnjs.cloudflare.com/ajax/libs/parallax/3.1.0/parallax.min.js")
-  
+
     script(src="./script.js")
   

--- a/src/script.js
+++ b/src/script.js
@@ -3,11 +3,13 @@ console.log("Script carregado! - DEV MODE");
 
 // Aguarda o DOM carregar completamente
 document.addEventListener('DOMContentLoaded', () => {
-	console.log("DOM carregado!");
-	
-	const scene = document.getElementById('scene');
-	const logo = document.querySelector(".logo");
-	const holoLines = document.querySelector('.holo-lines');
+        console.log("DOM carregado!");
+
+        const scene = document.getElementById('scene');
+        const logo = document.querySelector(".logo");
+        const menuToggle = document.getElementById('logo-menu-toggle');
+        const menu = document.getElementById('logo-menu');
+        const holoLines = document.querySelector('.holo-lines');
 	
 	console.log("Scene encontrada:", scene);
 	console.log("Logo encontrada:", logo);
@@ -48,7 +50,31 @@ document.addEventListener('DOMContentLoaded', () => {
 		}
 	});
 	
-	console.log("Parallax configurado!");
+        console.log("Parallax configurado!");
+
+        const logos = [
+                { nome: 'Logo padrão', file: './assets/one-branco.svg' },
+                { nome: 'Placeholder 1', file: './assets/logo-placeholder1.svg' },
+                { nome: 'Placeholder 2', file: './assets/logo-placeholder2.svg' },
+                { nome: 'Placeholder 3', file: './assets/logo-placeholder3.svg' }
+        ];
+
+        logos.forEach(({ nome, file }) => {
+                const btn = document.createElement('button');
+                btn.textContent = nome;
+                btn.className = 'logo-option';
+                btn.addEventListener('click', () => {
+                        logo.style.backgroundImage = `url(${file})`;
+                        menu.classList.remove('open');
+                });
+                menu.appendChild(btn);
+        });
+
+        if (menuToggle) {
+                menuToggle.addEventListener('click', () => {
+                        menu.classList.toggle('open');
+                });
+        }
 });
 
 // --- CÓDIGO ORIGINAL COMENTADO ---

--- a/src/style.scss
+++ b/src/style.scss
@@ -88,6 +88,44 @@
   /* Teste de watch - transformação removida temporariamente */
 }
 
+.logo-menu-toggle {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  z-index: 3;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  border: none;
+  padding: 0.5rem;
+  cursor: pointer;
+  border-radius: 0.25rem;
+}
+
+.logo-menu {
+  position: absolute;
+  top: 3.5rem;
+  right: 1rem;
+  z-index: 3;
+  background: rgba(0, 0, 0, 0.7);
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  display: none;
+  flex-direction: column;
+}
+
+.logo-menu.open {
+  display: flex;
+}
+
+.logo-option {
+  background: transparent;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  padding: 0.25rem 0;
+  text-align: left;
+}
+
 .holo-bg {
   border-radius: inherit;
   --size: 0;


### PR DESCRIPTION
## Summary
- criar botao de menu e area para seletor de logos
- adicionar estilos para menu colapsavel
- criar scripts para trocar a logo dinamicamente
- incluir 3 logos placeholders

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68656b97427c8333842c55524e7cc0de